### PR TITLE
hotfix/clinic-address-unlink-non-uw-site-324716072 > develop

### DIFF
--- a/templates/node/node--res-clinic--card.html.twig
+++ b/templates/node/node--res-clinic--card.html.twig
@@ -122,7 +122,7 @@
         #}
         {% if content.field_res_building.0|render|striptags|trim is not empty %}
           {% if not url_not_uwmedicine_org %}
-          <a href="{{ url }}#directions-tab" class="clinic-card__street-address-link">{{ content.field_res_building.0 }}</a>
+            <a href="{{ url }}#directions-tab" class="clinic-card__street-address-link">{{ content.field_res_building.0 }}</a>
           {% else %}
             {{ content.field_res_building.0 }}
           {% endif %}

--- a/templates/node/node--res-clinic--card.html.twig
+++ b/templates/node/node--res-clinic--card.html.twig
@@ -58,6 +58,10 @@
  * Via preprocess, the 'url' variable is overridden to link to corresponding
  * UWMed node as appropriate.
  *
+ * Custom variables:
+ * - url_not_uwmedicine_org: boolean, true if the 'url' links to a site other
+ *   than uwmedicine.org
+ *
  * @see template_preprocess_node()
  * @see uwmbase_preprocess_node()
  */
@@ -117,7 +121,11 @@
           @see /themes/custom/uwmed/src/js/node--uwm-clinic.js
         #}
         {% if content.field_res_building.0|render|striptags|trim is not empty %}
+          {% if not url_not_uwmedicine_org %}
           <a href="{{ url }}#directions-tab" class="clinic-card__street-address-link">{{ content.field_res_building.0 }}</a>
+          {% else %}
+            {{ content.field_res_building.0 }}
+          {% endif %}
         {% endif %}
       </address>
 

--- a/uwmbase.theme
+++ b/uwmbase.theme
@@ -151,6 +151,9 @@ function uwmbase_preprocess_node(&$variables, $hook) {
   _uwmbase_node_prepare_uwm_url($node);
   $variables['url'] = $node->uwm_url;
 
+  // Check if the URL is external to uwmedicine.org
+  $variables['url_not_uwmedicine_org'] = (strpos($node->uwm_url, 'uwmedicine.org') === FALSE);
+
   if (stripos($currentPath, '/provider-resource') !== FALSE) {
     $specialties = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term')


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=324716072

Remove address links for clinics that link to non-uwmedicine.org URLs.